### PR TITLE
Fix: Skip untracked directories in git status

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -302,6 +302,15 @@ func GetStatus(repoPath string) (*Status, error) {
 			// Untracked file
 			b = b[2:] // skip "? "
 			path, rest := readToNul(b)
+
+			// Skip directories - git status may show untracked directories (like empty git repos)
+			// but we can't meaningfully diff them
+			fullPath := filepath.Join(repoPath, string(path))
+			if info, err := os.Stat(fullPath); err == nil && info.IsDir() {
+				b = rest
+				continue
+			}
+
 			status.Files = append(status.Files, FileStatus{
 				Path:     string(path),
 				Unstaged: "untracked",


### PR DESCRIPTION
## Summary
- Filter out untracked directories from the file list
- Prevents error messages when trying to diff directories
- Only shows actual files that can be staged or diffed

## Problem
Git status reports untracked directories (like empty git repos) which kvist would display in the file list. When a user selected such a directory, kvist would attempt to diff it:

```
git diff --no-index -- /dev/null kvist-repo/
error: Could not access 'kvist-repo/null'
```

This produced confusing error messages and cluttered the file list with entries that couldn't be meaningfully interacted with.

## Solution
Added a directory check in the git status parsing logic (git/git.go:306-312):
- After parsing an untracked path from `git status --porcelain=v2`
- Check if the path is a directory using `os.Stat()`
- Skip it if it is - only add actual files to the status list

## Technical Details
**Root Cause:** Git status shows untracked directories with `? path/` even if they contain nested git repos or are empty. These show up as untracked items but can't be staged or diffed like regular files.

**Fix Location:** Modified the `case '?':` handler in `GetStatus()` to filter directories before adding them to `status.Files`.

## Test Plan
- [x] Build succeeds without errors
- [x] Created test directory with nested git repo (`kvist-repo/`)
- [x] Verified directory doesn't appear in kvist file list
- [x] Verified regular untracked files still appear correctly
- [x] No error messages when navigating file list

## Before/After
**Before:**
```
Files
  A kvist-repo/    <- Directory appears, causes errors
  A README.md
```

**After:**
```
Files
  A README.md      <- Only actual files shown
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)