### PR TITLE
Improve files mode layout with larger diff panel

### DIFF
--- a/main.go
+++ b/main.go
@@ -1657,9 +1657,18 @@ func (m model) renderHeader() string {
 }
 
 func (m model) renderContent(height int) string {
-	// Simple two-panel vertical layout
-	topHeight := height * 2 / 3
-	bottomHeight := height - topHeight
+	// Two-panel vertical layout with mode-specific splits
+	var topHeight, bottomHeight int
+
+	// Files mode: give more space to diff (bottom panel)
+	// Other modes: balanced split
+	if m.currentMode == filesMode {
+		topHeight = height * 2 / 5      // 40% for file list
+		bottomHeight = height - topHeight // 60% for diff
+	} else {
+		topHeight = height * 2 / 3      // 66% for top panel
+		bottomHeight = height - topHeight // 33% for bottom panel
+	}
 
 	// Content depends on current mode
 	var top, bottom string


### PR DESCRIPTION
## Summary
- Adjust pane split ratio in files mode to give more space to diff viewing
- Files mode: 40% file list, 60% diff panel (previously 66%/33%)
- Other modes unchanged

## Problem
In files mode, the file list took up 66% of the screen while the diff panel only had 33%. Since file lists are typically short (5-20 files) but diffs can be long, this caused excessive scrolling to review changes.

## Solution
Adjusted the split ratio specifically for files mode:
- **Files mode:** Top panel 40%, bottom panel 60%
- **Other modes:** Keep original 66%/33% split (workspace, history)

This gives 50% more vertical space to the diff panel in files mode, making it much easier to review changes.

## Before/After
**Before (files mode):**
```
┌─────────────────────┐
│                     │
│   File List (66%)   │
│                     │
├─────────────────────┤
│   Diff (33%)        │
└─────────────────────┘
```

**After (files mode):**
```
┌─────────────────────┐
│  File List (40%)    │
├─────────────────────┤
│                     │
│   Diff (60%)        │
│                     │
└─────────────────────┘
```

## Test Plan
- [x] Build succeeds without errors
- [x] Files mode shows 40/60 split
- [x] Other modes still use 66/33 split
- [x] Diff is more readable with extra space

🤖 Generated with [Claude Code](https://claude.com/claude-code)