### PR TITLE
Fix application freeze caused by double auto-refresh scheduling and git timeouts

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -48,7 +48,10 @@ func OpenRepository(path string) (*Repository, error) {
 		return nil, err
 	}
 
-	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "git", "rev-parse", "--show-toplevel")
 	cmd.Dir = absPath
 	output, err := cmd.Output()
 	if err != nil {
@@ -67,7 +70,10 @@ func OpenRepository(path string) (*Repository, error) {
 }
 
 func getCurrentBranch(repoPath string) (string, error) {
-	cmd := exec.Command("git", "branch", "--show-current")
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "git", "branch", "--show-current")
 	cmd.Dir = repoPath
 	output, err := cmd.Output()
 	if err != nil {
@@ -85,7 +91,10 @@ func GetCommits(repoPath string, limit int) ([]Commit, error) {
 	// %x1e = RS between commits, %x00 between fields
 	const logFmt = "%H%x00%h%x00%an%x00%ae%x00%at%x00%s%x00%b%x00%x1e"
 
-	cmd := exec.Command("git", "log", fmt.Sprintf("--max-count=%d", limit), "--format="+logFmt)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "git", "log", fmt.Sprintf("--max-count=%d", limit), "--format="+logFmt)
 	cmd.Dir = repoPath
 	output, err := cmd.Output()
 	if err != nil {
@@ -177,7 +186,10 @@ type Commit struct {
 }
 
 func GetBranches(repoPath string) ([]Branch, error) {
-	cmd := exec.Command("git", "branch", "-a")
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "git", "branch", "-a")
 	cmd.Dir = repoPath
 	output, err := cmd.Output()
 	if err != nil {
@@ -273,7 +285,10 @@ type Branch struct {
 
 func GetStatus(repoPath string) (*Status, error) {
 	// Use porcelain v2 with NUL-separated output for robust parsing
-	cmd := exec.Command("git", "status", "--porcelain=v2", "-z")
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "git", "status", "--porcelain=v2", "-z")
 	cmd.Dir = repoPath
 	output, err := cmd.Output()
 	if err != nil {
@@ -617,31 +632,46 @@ func UntrackedPatch(repoPath, rel string) (string, error) {
 }
 
 func StageFile(repoPath string, path string) error {
-	cmd := exec.Command("git", "add", path)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "git", "add", path)
 	cmd.Dir = repoPath
 	return cmd.Run()
 }
 
 func UnstageFile(repoPath string, path string) error {
-	cmd := exec.Command("git", "reset", "HEAD", path)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "git", "reset", "HEAD", path)
 	cmd.Dir = repoPath
 	return cmd.Run()
 }
 
 func CheckoutBranch(repoPath string, branch string) error {
-	cmd := exec.Command("git", "checkout", branch)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "git", "checkout", branch)
 	cmd.Dir = repoPath
 	return cmd.Run()
 }
 
 func CreateBranch(repoPath string, branch string) error {
-	cmd := exec.Command("git", "checkout", "-b", branch)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "git", "checkout", "-b", branch)
 	cmd.Dir = repoPath
 	return cmd.Run()
 }
 
 func GetRemotes(repoPath string) ([]Remote, error) {
-	cmd := exec.Command("git", "remote", "-v")
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "git", "remote", "-v")
 	cmd.Dir = repoPath
 	output, err := cmd.Output()
 	if err != nil {
@@ -696,7 +726,10 @@ type Remote struct {
 }
 
 func GetStashes(repoPath string) ([]Stash, error) {
-	cmd := exec.Command("git", "stash", "list", "--format=%gd%x00%gs%x00%gD")
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "git", "stash", "list", "--format=%gd%x00%gs%x00%gD")
 	cmd.Dir = repoPath
 	output, err := cmd.Output()
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -1205,16 +1205,14 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// Capture repo for closure
 			repo := m.repo
 			// Reload git status only (faster than full reload)
-			return m, tea.Batch(
-				func() tea.Msg {
-					status, err := git.GetStatus(repo.Path)
-					if err != nil {
-						return repoBasicsLoadedMsg{err: err}
-					}
-					return repoBasicsLoadedMsg{repo: repo, status: status}
-				},
-				autoRefreshCmd(), // Schedule next refresh
-			)
+			// Note: Don't schedule next refresh here - repoBasicsLoadedMsg handler will do it
+			return m, func() tea.Msg {
+				status, err := git.GetStatus(repo.Path)
+				if err != nil {
+					return repoBasicsLoadedMsg{err: err}
+				}
+				return repoBasicsLoadedMsg{repo: repo, status: status}
+			}
 		}
 		// If no repo loaded, don't schedule next refresh
 		return m, nil


### PR DESCRIPTION
## Summary
Fixes #15 - Resolves the critical freeze issue where the application becomes completely unresponsive after running for a while, requiring external kill.

This was confirmed to happen in both regular terminals and inside Zellij.

## Root Causes Fixed

### 1. Double Auto-Refresh Scheduling (CRITICAL)

The auto-refresh mechanism was scheduling itself **twice** on every cycle, causing exponential timer growth:

**Before:**
```
autoRefreshMsg fires → calls git.GetStatus() → returns repoBasicsLoadedMsg
  ↓ (schedules refresh at line 1216)
  ↓ (ALSO schedules refresh at line 1076)
Result: 2 timers → 4 timers → 8 timers → 16 timers...
```

After a few minutes, hundreds of concurrent `git status` calls would run every 5 seconds, completely overwhelming the system.

**After:**
```
autoRefreshMsg fires → calls git.GetStatus() → returns repoBasicsLoadedMsg
  ↓ (only schedules next refresh at line 1076)
Result: 1 timer maintained throughout
```

**Fix**: Removed duplicate `autoRefreshCmd()` call from `autoRefreshMsg` handler (main.go:1216). Now only `repoBasicsLoadedMsg` schedules the next refresh, maintaining a single timer.

### 2. Git Operations Without Timeouts (CRITICAL)

Many git operations had no timeout protection. If git hangs (SSH prompt, network timeout, large repo), the goroutine blocks **forever** and the entire app freezes - even Ctrl+C doesn't work because the main event loop is stuck.

**Fix**: Added 10-second timeouts to all critical git operations:
- `GetStatus()` - called by auto-refresh every 5 seconds
- `StageFile()`, `UnstageFile()` - user file operations
- `CheckoutBranch()`, `CreateBranch()` - branch operations
- `OpenRepository()`, `getCurrentBranch()` - repository initialization
- `GetCommits()` (15s timeout), `GetBranches()`, `GetRemotes()`, `GetStashes()`

All now use `context.WithTimeout()` and `exec.CommandContext()` for proper timeout handling.

## Changes
- **main.go**: Removed duplicate `autoRefreshCmd()` call from `autoRefreshMsg` handler
- **git/git.go**: Added context timeouts to 10+ git operation functions

## Test Plan
- [x] Build succeeds with no errors
- [ ] Manual testing: Leave kvist open for 10+ minutes, verify it doesn't freeze
- [ ] Manual testing: Verify git operations time out appropriately if they hang
- [ ] Manual testing: Confirm auto-refresh still works (updates every 5 seconds)

## Impact
This should completely eliminate the freeze issue. The app will now:
- Maintain only a single auto-refresh timer instead of exponentially growing timers
- Gracefully handle hung git operations by timing out after 10 seconds
- Remain responsive even if git commands take longer than expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)