### PR TITLE
Add branch deletion functionality to branch viewer

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -694,6 +694,28 @@ func CreateBranch(repoPath string, branch string) error {
 	return cmd.Run()
 }
 
+func DeleteBranch(repoPath string, branch string, force bool) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	flag := "-d"
+	if force {
+		flag = "-D"
+	}
+	cmd := exec.CommandContext(ctx, "git", "branch", flag, branch)
+	cmd.Dir = repoPath
+	return cmd.Run()
+}
+
+func DeleteRemoteBranch(repoPath string, remote string, branch string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "git", "push", remote, "--delete", branch)
+	cmd.Dir = repoPath
+	return cmd.Run()
+}
+
 func GetRemotes(repoPath string) ([]Remote, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()


### PR DESCRIPTION
## Summary
Adds the ability to delete branches directly from the branch menu (accessed with `b` key) by pressing `d` on the selected branch.

## Features
- Press `d` in branch menu to delete the selected branch
- Automatically detects if the branch exists on `origin`
- If remote exists, prompts user whether to also delete remotely (defaults to yes)
- Prevents deletion of the current branch
- Refreshes branch list after successful deletion
- Handles errors gracefully with informative messages

## UI Flow

### Branch Menu
Added `d: delete` to the help text in branch menu:
```
↑↓/jk: navigate • Enter: select • d: delete • Esc: cancel
```

### Remote Deletion Prompt
When deleting a branch that exists on origin:
```
╭────────────────────────────────────────╮
│ Delete branch 'feature/my-branch'      │
│ Also delete from remote (origin)?      │
│                                        │
│ [Yes]  [No]                            │
│                                        │
│ Tab: toggle • Y/Enter: yes • N: no ... │
╰────────────────────────────────────────╯
```

- Defaults to **[Yes]** (delete from both local and remote)
- Use Tab/Left/Right to toggle between Yes/No
- Press Y or Enter to confirm with current selection
- Press N to select No
- Press Esc to cancel deletion

### Local-Only Deletion
If branch doesn't exist on origin, it's deleted immediately without prompting.

## Implementation Details

### Git Package (git/git.go)
- `DeleteBranch(repoPath, branch, force)` - Deletes local branch (uses `-d` or `-D` flag)
- `DeleteRemoteBranch(repoPath, remote, branch)` - Deletes branch from remote

### Main Package (main.go)
- Added state variables: `deletingBranch`, `branchToDelete`, `deleteRemote`, `deleteRemotePrompt`
- Added `deleteBranchMsg` type and `deleteBranchCmd()` function for async deletion
- Added 'd' key handler in branch menu
- Added deleteRemotePrompt UI with yes/no toggle
- Added overlay rendering for confirmation prompt
- Refreshes repository state after deletion

## Test Plan
- [x] Build succeeds
- [ ] Can delete local-only branches
- [ ] Prompted when branch exists on remote  
- [ ] Can toggle yes/no in prompt
- [ ] Deletes both local and remote when selecting Yes
- [ ] Deletes only local when selecting No
- [ ] Cannot delete current branch
- [ ] Branch list refreshes after deletion
- [ ] Error messages display properly

## Context
This addresses the common issue where GitHub doesn't auto-delete branches after merging PRs, leaving stale remote branches that clutter the branch list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)